### PR TITLE
Add environment variable alias shim

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,10 +1,21 @@
-// external packages
+const dotenv = require('dotenv');
+if (process.env.NODE_ENV !== 'production') dotenv.config({ path: './.env' });
+
+// Alias Azure UPPERCASE -> legacy lowercase names used in code/SDK
+if (!process.env.AIRTABLE_API_KEY && process.env.PERSONAL_ACCESS_TOKEN) {
+  process.env.AIRTABLE_API_KEY = process.env.PERSONAL_ACCESS_TOKEN;
+}
+process.env.baseId          ||= process.env.BASE_ID;
+process.env.tableId         ||= process.env.TABLE_ID;
+process.env.content_tableID ||= process.env.CONTENT_TABLE_ID;
+process.env.personal_access_token ||= process.env.PERSONAL_ACCESS_TOKEN;
+
+// now require project modules that read env at import time
 const express = require('express');
 const cron = require('node-cron');
-require('dotenv').config();
 const test = require('./test');
 const WA = require('./wati');
-const airtable = require("./update");
+const airtable = require('./update');
 
 const webApp = express();
 webApp.use(express.json());


### PR DESCRIPTION
## Summary
- Map Azure-style uppercase environment variables to legacy lowercase names
- Support `AIRTABLE_API_KEY` fallback to `PERSONAL_ACCESS_TOKEN`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae72b0a9b88333905eb5a8a2e0971a