### PR TITLE
fix: ensure prod deps and port config in deploy

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -28,10 +28,19 @@ jobs:
       - name: 🏗️ Build (optional)
         run: npm run build --if-present
 
+      - name: Install prod deps
+        run: npm ci --omit=dev
+
       - name: 🔐 Azure login
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Disable remote build + pin PORT
+        run: |
+          az webapp config appsettings set \
+            -g TBS-rg_group -n TBS-rg \
+            --settings SCM_DO_BUILD_DURING_DEPLOYMENT=false PORT=8080
 
       - name: 🚀 Deploy to Azure Web App
         uses: azure/webapps-deploy@v2


### PR DESCRIPTION
## Summary
- install production dependencies and disable remote build before deployment
- pin PORT=8080 in Azure app settings to ensure port agreement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae74f55d24833393a0042af64cd344