### PR TITLE
chore: configure app settings in CI

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,3 @@
-git grep -nE "baseId|tableId|content_tableID|personal_access_token"
 # Server Configuration
 PORT=3000
 NODE_ENV=production
@@ -23,7 +22,5 @@ TZ=Asia/Kolkata
 LOG_LEVEL=info
 
 # Optional: Rate Limiting
-RATE_LIMIT_MAX=100
-RATE_LIMIT_WINDOW=900000
 RATE_LIMIT_MAX=100
 RATE_LIMIT_WINDOW=900000

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -32,15 +32,29 @@ jobs:
         run: npm ci --omit=dev
 
       - name: 🔐 Azure login
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Disable remote build + pin PORT
+      - name: Configure App Settings (idempotent)
+        run: |
+          az webapp config appsettings set -g TBS-rg_group -n TBS-rg --settings \
+            NODE_ENV=production PORT=8080 TZ=Asia/Kolkata \
+            PERSONAL_ACCESS_TOKEN='${{ secrets.PERSONAL_ACCESS_TOKEN }}' \
+            BASE_ID='${{ secrets.BASE_ID }}' \
+            TABLE_ID='${{ secrets.TABLE_ID }}' \
+            CONTENT_TABLE_ID='${{ secrets.CONTENT_TABLE_ID }}' \
+            API='${{ secrets.API }}' \
+            WEBHOOK_URL='https://tbs-rg-gxfnddazdmcgbedm.centralindia-01.azurewebsites.net'
+
+      - name: Enforce Health Check Path
+        run: az webapp update -g TBS-rg_group -n TBS-rg --set siteConfig.healthCheckPath="/ping"
+
+      - name: Disable remote build
         run: |
           az webapp config appsettings set \
             -g TBS-rg_group -n TBS-rg \
-            --settings SCM_DO_BUILD_DURING_DEPLOYMENT=false PORT=8080
+            --settings SCM_DO_BUILD_DURING_DEPLOYMENT=false
 
       - name: 🚀 Deploy to Azure Web App
         uses: azure/webapps-deploy@v2


### PR DESCRIPTION
## Summary
- configure Azure App Service environment variables during CI
- enforce a health check path for the web app
- clean up environment template and drop lowercase aliases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae7feefee08333bfd66946b102640a