### PR TITLE
Enable Azure remote build and trigger redeployment

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -50,11 +50,11 @@ jobs:
       - name: Enforce Health Check Path
         run: az webapp update -g TBS-rg_group -n TBS-rg --set siteConfig.healthCheckPath="/ping"
 
-      - name: Disable remote build
+      - name: Enable remote build
         run: |
           az webapp config appsettings set \
             -g TBS-rg_group -n TBS-rg \
-            --settings SCM_DO_BUILD_DURING_DEPLOYMENT=false
+            --settings SCM_DO_BUILD_DURING_DEPLOYMENT=true
 
       - name: 🚀 Deploy to Azure Web App
         uses: azure/webapps-deploy@v2

--- a/readme.md
+++ b/readme.md
@@ -208,3 +208,5 @@ This project is licensed under the ISC License - see the [LICENSE](LICENSE) file
 ---
 
 **Built with ❤️ for automated learning delivery**
+
+# Deployment fix Wed Aug 27 04:39:10 UTC 2025


### PR DESCRIPTION
## Summary
- enable remote build during deployment to restore missing node modules
- document deployment fix to trigger rebuild

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae8b8b2e048333be6f4d478649d982